### PR TITLE
Do not show the emoji title in reaction popup

### DIFF
--- a/src/services/slack/emoji.service.ts
+++ b/src/services/slack/emoji.service.ts
@@ -2,6 +2,7 @@ import { defaultEmojis } from './default_emoji';
 import { SlackClient } from './slack-client';
 
 import * as emojione from 'emojione';
+import * as $ from 'jquery';
 
 export class EmojiService {
     emojiList: { string: string };
@@ -21,16 +22,24 @@ export class EmojiService {
         }
     }
 
-    convertEmoji(emoji: string): string {
+    convertEmoji(emoji: string, withTitle = true, skinTone = 0): string {
         if (this.emojiList && !!this.emojiList[emoji.substr(1, emoji.length - 2)]) {
             const image_url = this.emojiList[emoji.substr(1, emoji.length - 2)];
             if (image_url.substr(0, 6) === 'alias:') {
                 return this.convertEmoji(`:${image_url.substr(6)}:`);
             } else {
-                return `<img class="emojione" title="${emoji.substr(1, emoji.length - 2)}" src="${image_url}" />`;
+                if (withTitle) {
+                    return `<img class="emojione" title="${emoji.substr(1, emoji.length - 2)}" src="${image_url}" />`;
+                } else {
+                    return `<img class="emojione" src="${image_url}" />`;
+                }
             }
         } else if (emoji !== emojione.shortnameToImage(emoji)) {
-            return emojione.shortnameToImage(emoji);
+            let $img = $(emojione.shortnameToImage(emoji));
+            if (!withTitle) {
+                $img.removeAttr('title');
+            }
+            return $img[0].outerHTML;
         } else {
             return emoji;
         }

--- a/src/services/slack/slack-parser.service.ts
+++ b/src/services/slack/slack-parser.service.ts
@@ -11,8 +11,32 @@ export class EmojiParser implements SlackParser {
     }
 
     parse(text: string, dataStore: DataStore): string {
-        return text.replace(/:[a-zA-Z0-9_+\-]+:/g, (value: string) => {
-            return this.emojiService.convertEmoji(value);
+        return text.replace(/(:[a-zA-Z0-9_+\-]+:)+/g, (value) => {
+            let emoji: string;
+            let withTitle: boolean;
+            let skinTone: number;
+            let ret = '';
+            value = value.substr(1, value.length - 2);
+
+            for (const v of value.split('::')) {
+                if (v === 'notitle') { // notitle modifier
+                    withTitle = false;
+                } else if (v.match('skin-tone-[1-9]')) { // TODO: skin-tone modifier
+                    skinTone = 0;
+                } else { // An emoji appears. Print the previous emoji with the found modifiers.
+                    if (!!emoji) {
+                        ret += this.emojiService.convertEmoji(emoji, withTitle, skinTone);
+                    }
+                    // Reset modifiers for the next emoji.
+                    emoji = ':' + v + ':';
+                    withTitle = true;
+                    skinTone = 0;
+                }
+            }
+
+            ret += this.emojiService.convertEmoji(emoji, withTitle, skinTone);
+
+            return ret;
         });
     }
 }

--- a/src/services/slack/slack-parser.service.ts
+++ b/src/services/slack/slack-parser.service.ts
@@ -16,27 +16,34 @@ export class EmojiParser implements SlackParser {
             let withTitle: boolean;
             let skinTone: number;
             let ret = '';
-            value = value.substr(1, value.length - 2);
+            const str = value.substr(1, value.length - 2);
 
-            for (const v of value.split('::')) {
-                if (v === 'notitle') { // notitle modifier
+            for (const s of str.split('::')) {
+                if (s === 'notitle') { // notitle modifier
                     withTitle = false;
-                } else if (v.match('skin-tone-[1-9]')) { // TODO: skin-tone modifier
+                } else if (s.match('skin-tone-[1-9]')) { // TODO: skin-tone modifier
                     skinTone = 0;
                 } else { // An emoji appears. Print the previous emoji with the found modifiers.
                     if (!!emoji) {
                         ret += this.emojiService.convertEmoji(emoji, withTitle, skinTone);
                     }
                     // Reset modifiers for the next emoji.
-                    emoji = ':' + v + ':';
+                    emoji = ':' + s + ':';
                     withTitle = true;
                     skinTone = 0;
                 }
             }
 
-            ret += this.emojiService.convertEmoji(emoji, withTitle, skinTone);
+            if (!!emoji) {
+                ret += this.emojiService.convertEmoji(emoji, withTitle, skinTone);
+            }
 
-            return ret;
+            if (ret === '') {
+                // something matched but no emoji found (e.g. value == ':notitle:')
+                return value;
+            } else {
+                return ret;
+            }
         });
     }
 }

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -74,7 +74,7 @@ export class DisplaySlackMessageInfo {
 
 
     addReaction(info: SlackReactionAdded) {
-        const reaction = this.parser.parse(`:${info.reaction.reaction}:`, this.message.dataStore);
+        const reaction = this.parser.parse(`:${info.reaction.reaction}::notitle:`, this.message.dataStore);
         const user = info.reaction.user;
         const target = this.reactions.find(r => r.reaction === reaction);
 
@@ -86,7 +86,7 @@ export class DisplaySlackMessageInfo {
     }
 
     removeReaction(info: SlackReactionRemoved) {
-        const reaction = this.parser.parse(`:${info.reaction.reaction}:`, this.message.dataStore);
+        const reaction = this.parser.parse(`:${info.reaction.reaction}::notitle:`, this.message.dataStore);
         const target = this.reactions.find(r => r.reaction === reaction);
 
         if (target) {


### PR DESCRIPTION
What this PR does:
1. Parse messages including `::` (e.g. `:+1::skin-tone-4:`, `:+1::+1::skin-tone-4:`) correctly by introducing a new "modifier" concept.
2. Add a new modifier `notitle` so that the title of an emoji is not displayed in reaction popups.