### PR TITLE
Display shortened emoji name when one is longer than 15 chars

### DIFF
--- a/src/components/slack/form/message.component.ts
+++ b/src/components/slack/form/message.component.ts
@@ -68,7 +68,13 @@ export class MessageFormComponent implements OnChanges, OnDestroy {
                              }));
                 },
                 template: (value) => {
-                    return `${this.emoji.convertEmoji(':' + value + ':')} ${value}`;
+                    let shortName: string;
+                    if (value.length > 15) {
+                        shortName = value.substr(0, 15) + '...';
+                    } else {
+                        shortName = value;
+                    }
+                    return `${this.emoji.convertEmoji(':' + value + ':')} ${shortName}`;
                 },
                 replace: (value) => {
                     this.emoji.useEmoji(value);


### PR DESCRIPTION
Fix #113 

![long_emoji_name](https://user-images.githubusercontent.com/11990836/28210307-b7ae8f50-68d1-11e7-8156-a8abcf461e8f.png)
