### PR TITLE
zip packages with multiple processes

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -15,9 +15,11 @@ electron-packager package slack-stream --platform=linux --arch=all --overwrite
 for f in slack-stream*
 do
     cp 3rdpartylicenses.txt $f/LICENSES.3rdParty
-    echo "Creating zip: $f.zip"
-    zip $f.zip -r $f > /dev/null
 done
+
+n_cores=`grep processor /proc/cpuinfo | wc -l`
+echo "Creating zips using ${n_cores} processes"
+parallel -j ${n_cores} zip {}.zip -r {} > /dev/null ::: `find -name "slack-stream-*"`
 
 rm -f 3rdpartylicenses.txt
 rm -rf package


### PR DESCRIPTION
This PR creates zip files of the packages using the same number of processes with the number of cores. Using 2 cores reduces an execution of `package.sh` from around 1:30 to around 1:00 in my environment.

Some notes:
- GNU parallel must be installed (by # apt-get install parallel)
- Applying the same to `electron-packager` did not work in my environment with weird errors. I guess `electron-packager` does something non-functional (with side-effects) inside the packaged directory.