### PR TITLE
Fix build script: look only the current directory for package targets

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -19,7 +19,7 @@ done
 
 n_cores=`grep processor /proc/cpuinfo | wc -l`
 echo "Creating zips using ${n_cores} processes"
-parallel -j ${n_cores} zip {}.zip -r {} > /dev/null ::: `find -name "slack-stream-*"`
+parallel -j ${n_cores} zip {}.zip -r {} > /dev/null ::: `find -maxdepth 1 -name "slack-stream-*"`
 
 rm -f 3rdpartylicenses.txt
 rm -rf package


### PR DESCRIPTION
Fix #115 

Because of the way we put the resulting zip files, `find -name "slack-stream-*"` find some extra files that should not be archived. This PR mitigates this problem by checking the current directly only by `-maxdepth 1`.