### PR TITLE
Simplify data movement between SettingComponent and SettingService

### DIFF
--- a/src/components/setting/setting.component.html
+++ b/src/components/setting/setting.component.html
@@ -7,7 +7,7 @@
 
         <div *ngFor="let index of tokenIndexes">
             <div class="input-group token">
-                <input type="text" class="form-control" [(ngModel)]="tokens[index]" placeholder="Your token">
+                <input type="text" class="form-control" [(ngModel)]="setting.tokens[index]" placeholder="Your token">
                 <span class="input-group-btn">
                     <button class="btn" (click)="removeToken(index)">
                         <span class="glyphicon glyphicon-remove"></span>
@@ -20,17 +20,17 @@
 
         <h3>View Settings</h3>
         <div>
-            <input type="checkbox" value="true" id="hide-buttons-checkbox" [(ngModel)]="hideButtons">
+            <input type="checkbox" value="true" id="hide-buttons-checkbox" [(ngModel)]="setting.hideButtons">
             <label for="hide-buttons-checkbox">Hide buttons</label>
         </div>
 
         <h3>Image expansion</h3>
         <div>
-            <input type="radio" name="img_exp" value="normal" id="image-expansion-normal" [(ngModel)]="imageExpansion">
+            <input type="radio" name="img_exp" value="normal" id="image-expansion-normal" [(ngModel)]="setting.imageExpansion">
             <label for="image-expansion-normal">Normal</label>
-            <input type="radio" name="img_exp" value="small" id="image-expansion-small" [(ngModel)]="imageExpansion">
+            <input type="radio" name="img_exp" value="small" id="image-expansion-small" [(ngModel)]="setting.imageExpansion">
             <label for="image-expansion-small">Small</label>
-            <input type="radio" name="img_exp" value="never" id="image-expansion-never" [(ngModel)]="imageExpansion">
+            <input type="radio" name="img_exp" value="never" id="image-expansion-never" [(ngModel)]="setting.imageExpansion">
             <label for="image-expansion-never">Never</label>
         </div>
 

--- a/src/components/setting/setting.component.ts
+++ b/src/components/setting/setting.component.ts
@@ -8,21 +8,11 @@ import { SettingService } from '../../services/setting.service';
     styles: [require('./setting.component.css').toString()]
 })
 export class SettingComponent implements OnInit {
-    tokens: string[];
-    hideButtons: boolean;
-    imageExpansion: string;
-
     get tokenIndexes(): number[] {
-        return this.tokens.map((elem, index, array) => index);
+        return this.setting.tokens.map((elem, index, array) => index);
     }
 
     constructor(public setting: SettingService, private router: Router) {
-        this.tokens = this.setting.tokens;
-        this.hideButtons = this.setting.hideButtons;
-        this.imageExpansion = this.setting.imageExpansion;
-        if (this.tokens.length === 0) {
-            this.tokens = [''];
-        }
     }
 
     ngOnInit() {
@@ -30,18 +20,15 @@ export class SettingComponent implements OnInit {
     }
 
     addToken() {
-        this.tokens.push('');
+        this.setting.tokens.push('');
     }
 
     exit() {
-        this.setting.setting.tokens = this.tokens;
-        this.setting.setting.hideButtons = this.hideButtons;
-        this.setting.setting.imageExpansion = this.imageExpansion;
         this.setting.save();
         this.router.navigate(['/']);
     }
 
     removeToken(index: number) {
-        this.tokens.splice(index, 1);
+        this.setting.tokens.splice(index, 1);
     }
 }

--- a/src/services/setting.service.ts
+++ b/src/services/setting.service.ts
@@ -20,12 +20,24 @@ export class SettingService {
         return this.setting.tokens;
     }
 
+    set tokens(tokens: string[]) {
+        this.setting.tokens = tokens;
+    }
+
     get hideButtons(): boolean {
         return this.setting.hideButtons;
     }
 
+    set hideButtons(hideButtons: boolean) {
+        this.setting.hideButtons = hideButtons;
+    }
+
     get imageExpansion(): string {
         return this.setting.imageExpansion;
+    }
+
+    set imageExpansion(imageExpansion: string) {
+        this.setting.imageExpansion = imageExpansion;
     }
 
     constructor() {
@@ -35,9 +47,9 @@ export class SettingService {
             this.setting = {} as Setting;
         }
 
-        if (this.setting.tokens === undefined) { this.setting.tokens = []; }
-        if (this.setting.hideButtons === undefined) { this.setting.hideButtons = false; }
-        if (this.setting.imageExpansion === undefined) { this.setting.imageExpansion = 'normal'; }
+        if (this.tokens === undefined) { this.tokens = ['']; }
+        if (this.hideButtons === undefined) { this.hideButtons = false; }
+        if (this.imageExpansion === undefined) { this.imageExpansion = 'normal'; }
     }
 
     save() {


### PR DESCRIPTION
It's a part of the refactoring-setting-related-code project (#142).

The current code copies setting data from SettingService to SettingComponent, but it's just redundant and we can just refer the data from SettingComponent directly without copying them.