### PR TITLE
Generalize radio buttons

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { SlackListComponent } from '../components/slack/list/slacklist.component
 import { SlackAttachmentComponent } from '../components/slack/attachment/attachment.component';
 import { SettingComponent } from '../components/setting/setting.component';
 import { TeamIconComponent } from '../components/slack/team/icon.component';
+import { RadioButtonComponent } from '../components/setting/radiobutton/radiobutton.component';
 
 // pipes
 import { ChannelColorPipe, TimeStampPipe } from '../pipes/slack';
@@ -47,6 +48,7 @@ const appRoutes: Routes = [
     SlackAttachmentComponent,
     SettingComponent,
     TeamIconComponent,
+    RadioButtonComponent,
 
     // pipes
     ChannelColorPipe,

--- a/src/components/setting/radiobutton/radiobutton.component.html
+++ b/src/components/setting/radiobutton/radiobutton.component.html
@@ -1,0 +1,7 @@
+<h3>{{button.title}}</h3>
+<div>
+  <span *ngFor="let choice of choices">
+    <input type="radio" [name]="button.name" [value]="choice.value" [id]="choice.id" [(ngModel)]="selected">
+    <label [for]="choice.id">{{choice.value}}</label>
+  </span>
+</div>

--- a/src/components/setting/radiobutton/radiobutton.component.ts
+++ b/src/components/setting/radiobutton/radiobutton.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { RadioButton, RadioButtonChoice } from './radiobutton';
+
+@Component({
+    selector: 'ss-radiobutton',
+    templateUrl: './radiobutton.component.html',
+    styles: []
+})
+export class RadioButtonComponent implements OnInit {
+    @Input() button: RadioButton;
+
+    ngOnInit() {
+    }
+
+    constructor() {
+    }
+
+    get title(): string {
+        return this.button.title;
+    }
+
+    get choices(): RadioButtonChoice[] {
+        return this.button.choices;
+    }
+
+    get selected(): string {
+        return this.button.selected;
+    }
+
+    set selected(value: string) {
+        let found = false;
+
+        for (const choice of this.button.choices) {
+            if (choice.value === value) {
+                found = true;
+            }
+        }
+
+        if (!found) {
+            throw 'selected value is invalid';
+        } else {
+            this.button.selected = value;
+        }
+    }
+}

--- a/src/components/setting/radiobutton/radiobutton.ts
+++ b/src/components/setting/radiobutton/radiobutton.ts
@@ -1,0 +1,34 @@
+export interface RadioButtonChoice {
+    id: string;
+    value: string;
+}
+
+export interface RadioButton {
+    choices: RadioButtonChoice[];
+    name: string;
+    title: string;
+    selected: string;
+}
+
+export class RadioButtonFactory {
+    static get(title: string, choiceValues: string[], defaultValue: string): RadioButton {
+        let button = {} as RadioButton;
+
+        if (choiceValues.indexOf(defaultValue) < 0) {
+            throw 'defaultValue is invalid';
+        }
+
+        button.name = title.replace(/ /g, '_');
+        button.title = title;
+        button.choices = [];
+        button.selected = defaultValue;
+        for (const choiceValue of choiceValues) {
+            let choice = {} as RadioButtonChoice;
+            choice.value = choiceValue;
+            choice.id = button.name + '_' + choice.value;
+            button.choices.push(choice);
+        }
+
+        return button;
+    }
+}

--- a/src/components/setting/setting.component.html
+++ b/src/components/setting/setting.component.html
@@ -24,16 +24,7 @@
             <label for="hide-buttons-checkbox">Hide buttons</label>
         </div>
 
-        <h3>Image expansion</h3>
-        <div>
-            <input type="radio" name="img_exp" value="normal" id="image-expansion-normal" [(ngModel)]="setting.imageExpansion">
-            <label for="image-expansion-normal">Normal</label>
-            <input type="radio" name="img_exp" value="small" id="image-expansion-small" [(ngModel)]="setting.imageExpansion">
-            <label for="image-expansion-small">Small</label>
-            <input type="radio" name="img_exp" value="never" id="image-expansion-never" [(ngModel)]="setting.imageExpansion">
-            <label for="image-expansion-never">Never</label>
-        </div>
-
+        <ss-radiobutton [button]="setting.imageExpansionSize"></ss-radiobutton>
     </div>
 
     <hr>

--- a/src/components/slack/attachment/attachment.component.ts
+++ b/src/components/slack/attachment/attachment.component.ts
@@ -39,7 +39,7 @@ export class SlackAttachmentComponent {
     }
 
     get showImage(): boolean {
-        if (!!this.attachment['image_url'] && this.setting.imageExpansion !== 'never') {
+        if (!!this.attachment['image_url'] && this.setting.imageExpansionSize.selected !== 'Never') {
             return true;
         } else {
             return false;
@@ -47,6 +47,6 @@ export class SlackAttachmentComponent {
     }
 
     get smallImage(): boolean {
-        return (this.setting.imageExpansion === 'small');
+        return (this.setting.imageExpansionSize.selected === 'Small');
     }
 }

--- a/src/services/setting.service.ts
+++ b/src/services/setting.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { RadioButton, RadioButtonFactory } from '../components/setting/radiobutton/radiobutton';
 import * as fs from 'fs';
 
 let settingPath = '';
@@ -9,7 +10,7 @@ export function setSettingPath(path: string) {
 interface Setting {
     tokens: string[];
     hideButtons: boolean;
-    imageExpansion: string;
+    imageExpansionSize: RadioButton;
 }
 
 @Injectable()
@@ -32,12 +33,12 @@ export class SettingService {
         this.setting.hideButtons = hideButtons;
     }
 
-    get imageExpansion(): string {
-        return this.setting.imageExpansion;
+    get imageExpansionSize(): RadioButton {
+        return this.setting.imageExpansionSize;
     }
 
-    set imageExpansion(imageExpansion: string) {
-        this.setting.imageExpansion = imageExpansion;
+    set imageExpansionSize(imageExpansionSize: RadioButton) {
+        this.setting.imageExpansionSize = imageExpansionSize;
     }
 
     constructor() {
@@ -49,7 +50,9 @@ export class SettingService {
 
         if (this.tokens === undefined) { this.tokens = ['']; }
         if (this.hideButtons === undefined) { this.hideButtons = false; }
-        if (this.imageExpansion === undefined) { this.imageExpansion = 'normal'; }
+        if (this.imageExpansionSize === undefined) {
+            this.imageExpansionSize = RadioButtonFactory.get('Image Expansion', ['Normal', 'Small', 'Never'], 'Normal');
+        }
     }
 
     save() {


### PR DESCRIPTION
It's a part of the refactoring-setting-related-code project (#142).

Creating a radio button is now as easy as making an object:

```
button1 = new RadioButton('Title of the button', ['choice1', 'choice2', ...], 'default_choice');
```

and putting a component using the object:

```
<ss-radiobutton [button]="setting.button1"></ss-radiobutton>
```