### PR TITLE
Toggle enable/disable tokens

### DIFF
--- a/src/components/setting/setting.component.html
+++ b/src/components/setting/setting.component.html
@@ -7,10 +7,16 @@
 
         <div *ngFor="let index of tokenIndexes">
             <div class="input-group token">
-                <input type="text" class="form-control" [(ngModel)]="setting.tokens[index]" placeholder="Your token">
+                <input type="text" class="form-control" [(ngModel)]="setting.tokens[index].value" placeholder="Your token" [disabled]="!setting.tokens[index].enabled">
                 <span class="input-group-btn">
                     <button class="btn" (click)="removeToken(index)">
                         <span class="glyphicon glyphicon-remove"></span>
+                    </button>
+                    <button *ngIf="setting.tokens[index].enabled" class="btn" (click)="toggleToken(index)">
+                        <span class="glyphicon glyphicon-volume-up"></span>
+                    </button>
+                    <button *ngIf="!setting.tokens[index].enabled" class="btn" (click)="toggleToken(index)">
+                        <span class="glyphicon glyphicon-volume-off"></span>
                     </button>
                 </span>
             </div>

--- a/src/components/setting/setting.component.ts
+++ b/src/components/setting/setting.component.ts
@@ -33,12 +33,6 @@ export class SettingComponent implements OnInit {
     }
 
     toggleToken(index: number) {
-        const currentlyEnabled =  this.setting.tokens[index].enabled;
-
-        if (currentlyEnabled) {
-            this.setting.tokens[index].enabled = false;
-        } else {
-            this.setting.tokens[index].enabled = true;
-        }
+        this.setting.tokens[index].enabled = !this.setting.tokens[index].enabled;
     }
 }

--- a/src/components/setting/setting.component.ts
+++ b/src/components/setting/setting.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { SettingService } from '../../services/setting.service';
+import { SettingService, Token } from '../../services/setting.service';
 
 @Component({
     selector: 'ss-setting',
@@ -20,7 +20,7 @@ export class SettingComponent implements OnInit {
     }
 
     addToken() {
-        this.setting.tokens.push('');
+        this.setting.tokens.push({ value: '', enabled: true } as Token);
     }
 
     exit() {
@@ -30,5 +30,15 @@ export class SettingComponent implements OnInit {
 
     removeToken(index: number) {
         this.setting.tokens.splice(index, 1);
+    }
+
+    toggleToken(index: number) {
+        const currentlyEnabled =  this.setting.tokens[index].enabled;
+
+        if (currentlyEnabled) {
+            this.setting.tokens[index].enabled = false;
+        } else {
+            this.setting.tokens[index].enabled = true;
+        }
     }
 }

--- a/src/components/slack/list/slacklist.component.ts
+++ b/src/components/slack/list/slacklist.component.ts
@@ -59,7 +59,8 @@ export class SlackListComponent implements OnInit, OnDestroy {
     }
 
     get filteredMessages(): DisplaySlackMessageInfo[] {
-        return this.messages.filter(m => this.filterContext.shouldShow(m));
+        const filteredByWorkplace = this.messages.filter(m => this.setting.isTokenEnabled(m.client.token));
+        return filteredByWorkplace.filter(m => this.filterContext.shouldShow(m));
     }
 
     get doesHaveMultipleTeams(): boolean {

--- a/src/services/setting.service.ts
+++ b/src/services/setting.service.ts
@@ -55,10 +55,12 @@ function MigrateSettingVer1ToVer2(oldSetting: SettingVer1): SettingVer2 {
     return newSetting;
 }
 
+const currentSettingVersion = 2;
+type SettingCurrent = SettingVer2;
+
 @Injectable()
 export class SettingService {
-    currentSettingVersion: number = 2;
-    setting: SettingVer2;
+    setting: SettingCurrent;
     settingMigrations: any[];
 
     get tokens(): Token[] {
@@ -108,11 +110,11 @@ export class SettingService {
         this.settingMigrations.push(MigrateSettingVer1ToVer2);
 
         let migrated = false;
-        for (let v = loadedSetting.version; v < this.currentSettingVersion; v++) {
+        for (let v = loadedSetting.version; v < currentSettingVersion; v++) {
             migrated = true;
             loadedSetting = this.settingMigrations[v](loadedSetting);
         }
-        this.setting = loadedSetting as SettingVer2;
+        this.setting = loadedSetting as SettingCurrent;
 
         // save if a migration is invoked
         if (migrated) {

--- a/src/services/setting.service.ts
+++ b/src/services/setting.service.ts
@@ -95,7 +95,7 @@ export class SettingService {
         let loadedSetting: Setting;
         try {
             loadedSetting = JSON.parse(fs.readFileSync(settingPath, 'utf8'));
-            // if setting.json exists but no version number is included, support it is version 1
+            // if setting.json exists but no version number is included, suppose it is version 1
             if (loadedSetting.version === undefined) {
                 loadedSetting.version = 1;
             }

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -128,8 +128,9 @@ export class SlackService {
             cache[slack.token] = [slack, false];
         }
 
-        this.clients = this.setting.tokens.map(token => {
+        this.clients = this.setting.tokens.map(t => {
             let client: SlackClient;
+            const token: string = t.value;
             if (cache[token]) {
                 client = cache[token][0];
                 cache[token][1] = true;


### PR DESCRIPTION
This PR allows users to enable/disable each token by clicking the newly added buttons (surrounded by a red circle in the screenshot).

Disabled tokens are grayed-out and messages received from that workplace (a.k.a. team) are not shown.

![toggle_token](https://user-images.githubusercontent.com/11990836/33236648-5699903a-d29d-11e7-9906-befac641b74c.png)
