### PR TITLE
Use user.profile.display_name instead of user.name

### DIFF
--- a/src/services/slack/slack-client.ts
+++ b/src/services/slack/slack-client.ts
@@ -81,12 +81,12 @@ export class SlackMessage {
     get userName(): string {
         if (this.message.comment) {
             const user = this.dataStore.getUserById(this.message.comment.user);
-            return user ? user.name : '???';
+            return user ? user.profile.display_name : '???';
         }
 
         if (this.message.user) {
             const user = this.dataStore.getUserById(this.message.user);
-            return user ? user.name : '???';
+            return user ? user.profile.display_name : '???';
         }
 
         if (this.message.bot_id) {

--- a/src/services/slack/slack.types.ts
+++ b/src/services/slack/slack.types.ts
@@ -170,6 +170,8 @@ export interface UserProfile {
     image_72: string;
     image_192: string;
     image_512: string;
+
+    display_name: string;
 }
 
 export interface Members {


### PR DESCRIPTION
Fix #154.

`user.name` is now deprecated and `user.profile.display_name` contains what we want (c.f. https://api.slack.com/changelog/2017-09-the-one-about-usernames)