### PR TITLE
fix avatar of shared messages

### DIFF
--- a/src/components/slack/attachment/attachment.component.html
+++ b/src/components/slack/attachment/attachment.component.html
@@ -2,7 +2,7 @@
     <div class="left" style="width: 100%;">
         <!-- Author -->
         <span *ngIf="!!attachment.author_link" class="author">
-            <img *ngIf="!!attachment.author_icon" [src]="attachment.author_icon" class="author-icon" />
+            <img *ngIf="!!attachment.author_icon" [src]="authorIcon" class="author-icon" />
             <span>
                 <a class="author-name" [href]="attachment.author_link">{{attachment.author_name}}</a>
 

--- a/src/components/slack/attachment/attachment.component.ts
+++ b/src/components/slack/attachment/attachment.component.ts
@@ -26,6 +26,11 @@ export class SlackAttachmentComponent {
         return this.attachmentTextParser.parse(text, this.dataStore);
     }
 
+    get authorIcon(): string {
+        const user = this.dataStore.getUserById(this.attachment.author_id);
+        return user.profile.image_32;
+    }
+
     get borderColor(): string {
         if (this.attachment.color) {
             if (this.attachment.color[0] === '#') {

--- a/src/services/slack/slack.types.ts
+++ b/src/services/slack/slack.types.ts
@@ -30,6 +30,7 @@ export interface Attachment {
     title: string;
     title_link: string;
 
+    author_id: string;
     author_icon: string;
     author_link: string;
     author_name: string;


### PR DESCRIPTION
Fix #151.

`attachment.author_id` exists in messages posted both by the official client and by an API.