### PR TITLE
Revert "Remove dependency on ChangeDetectorRef"

### DIFF
--- a/src/components/slack/list/slacklist.component.ts
+++ b/src/components/slack/list/slacklist.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectorRef, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { SlackService, DisplaySlackMessageInfo, DisplaySlackReactionInfo } from '../../../services/slack/slack.service';
 import { SlackClient } from '../../../services/slack/slack-client';
@@ -82,6 +82,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
     constructor(
         private slack: SlackService,
         private events: GlobalEventService,
+        private detector: ChangeDetectorRef,
         private router: Router,
         private setting: SettingService
     ) {
@@ -129,6 +130,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
                 }
             }).length;
         });
+        this.detector.detectChanges();
     }
 
     onClickWrite(info: DisplaySlackMessageInfo) {
@@ -140,6 +142,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
             null,
             this.filteredMessages
         );
+        this.detector.detectChanges();
     }
 
     onClickReply(info: DisplaySlackMessageInfo) {
@@ -151,6 +154,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
             info.message.threadTs ? info.message.threadTs : info.message.ts,
             this.filteredMessages
         );
+        this.detector.detectChanges();
     }
 
     onClickSendDM(info: DisplaySlackMessageInfo) {
@@ -162,6 +166,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
             null,
             this.messages
         );
+        this.detector.detectChanges();
     }
 
     onClickDelete(info: DisplaySlackMessageInfo) {
@@ -175,6 +180,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
             this.filterContext = new SoloChannelFilterContext(info.message.channelID);
             this.mutedChannels = [];
         }
+        this.detector.detectChanges();
     }
 
     onClickDisableMuteMode(channelID: string) {
@@ -187,6 +193,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
         } else {
             this.filterContext = new MuteChannelFilterContext(this.mutedChannels.map(ch => ch.ID));
         }
+        this.detector.detectChanges();
     }
 
     onClickMuteMode(info: DisplaySlackMessageInfo) {
@@ -198,15 +205,18 @@ export class SlackListComponent implements OnInit, OnDestroy {
         }).message.ts;
         this.mutedChannels.push(new MutedChannel(info, lastTsOfThisCh));
         this.filterContext = new MuteChannelFilterContext(this.mutedChannels.map(ch => ch.ID));
+        this.detector.detectChanges();
     }
 
     onClickEdit(info: DisplaySlackMessageInfo) {
         this.submitContext = new EditMessageContext(info.client, info.message);
+        this.detector.detectChanges();
     }
 
     async submitForm(text: string) {
         if (this.submitContext != null) {
             this.submitting = true;
+            this.detector.detectChanges();
 
             await this.submitContext.submit(text).catch(
                 // slack server may have returned an error. print the error and continue
@@ -214,11 +224,13 @@ export class SlackListComponent implements OnInit, OnDestroy {
 
             this.submitting = false;
             this.submitContext = null;
+            this.detector.detectChanges();
         }
     }
 
     closeForm() {
         this.submitContext = null;
+        this.detector.detectChanges();
     }
 
     onClickReaction(reaction: DisplaySlackReactionInfo) {
@@ -231,14 +243,16 @@ export class SlackListComponent implements OnInit, OnDestroy {
     }
 
     onMouseEnterReaction(reaction: DisplaySlackReactionInfo) {
+        reaction.showReactedUsers = true;
         this.showingReactedUsers = setTimeout(() => {
-            reaction.showReactedUsers = true;
+            this.detector.detectChanges();
         }, 500);
     }
 
     onMouseLeaveReaction(reaction: DisplaySlackReactionInfo) {
         reaction.showReactedUsers = false;
         clearTimeout(this.showingReactedUsers);
+        this.detector.detectChanges();
     }
 
     activateMessageForm() {
@@ -254,6 +268,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
                     message.message.threadTs,
                     messages
                 );
+                this.detector.detectChanges();
             }
         }
     }
@@ -273,12 +288,14 @@ export class SlackListComponent implements OnInit, OnDestroy {
         if (this.submitContext) {
             this.submitContext.changeMessageRequest(next);
         }
+        this.detector.detectChanges();
     }
 
     onChangeChannelRequest(next: boolean) {
         if (this.submitContext) {
             this.submitContext.changeChannelRequest(next);
         }
+        this.detector.detectChanges();
     }
 
     onClickSetting() {
@@ -296,6 +313,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
         }
 
         this.submitContext = null;
+        this.detector.detectChanges();
         setTimeout(() => {
             this.submitContext = new PostMessageContext(
                 client,
@@ -305,6 +323,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
                 null,
                 this.filteredMessages
             );
+            this.detector.detectChanges();
         }, 1);
     }
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,6 +1,6 @@
 import 'core-js/es6';
 import 'core-js/es7/reflect';
-require('zone.js/dist/zone-mix');
+require('zone.js/dist/zone');
 
 if (process.env.ENV !== 'development') {
     // Production


### PR DESCRIPTION
Reverts mazun/SlackStream#168.

It seems like the new (automatic) change detection is triggered every time a key is hit in the message posting form, which is unnecessary because hitting a key on the form does not change any internal state. 

This greatly penalizes the performance and user experiences, so it's better to revert to the old (manual) change detection.