### PR TITLE
Remove SlackClient from DisplaySlackMessageInfo

### DIFF
--- a/src/components/slack/list/slacklist.component.html
+++ b/src/components/slack/list/slacklist.component.html
@@ -30,8 +30,8 @@
                         <span class="glyphicon glyphicon-remove" (click)="closeSearchChannelModal()"></span>
                     </div>
                     <select name="selectedChannel" class="search-channel-form" style="width: 100%;" #selectedChannel>
-                        <ng-container *ngFor="let slackService of slackServices" >
-                            <option *ngFor="let channel of slackService.memberChannels" [value]="slackService.dataStore.teamID + '-' + channel['id']">{{slackService.team.name}}: {{channel['name']}}</option>
+                        <ng-container *ngFor="let client of slack.clients" >
+                            <option *ngFor="let channel of client.memberChannels" [value]="client.teamID + '-' + channel['id']">{{client.team.name}}: {{channel['name']}}</option>
                         </ng-container>
                     </select>
                 </div>

--- a/src/components/slack/list/submit-context.ts
+++ b/src/components/slack/list/submit-context.ts
@@ -1,7 +1,7 @@
 import { SlackMessage, SlackClient } from '../../../services/slack/slack-client';
 import { DataStore } from '../../../services/slack/slack.types';
 import { EmojiService } from '../../../services/slack/emoji.service';
-import { DisplaySlackMessageInfo } from '../../../services/slack/slack.service';
+import { SlackService, DisplaySlackMessageInfo } from '../../../services/slack/slack.service';
 import { SlackUtil } from '../../../services/slack/slack-util';
 
 export interface SubmitContext {
@@ -24,14 +24,17 @@ export interface SubmitContext {
 }
 
 export class PostMessageContext implements SubmitContext {
+    public client: SlackClient;
+
     constructor(
-        public client: SlackClient,
+        public slack: SlackService,
         public channelLikeID: string,
         public teamID: string,
         public ts: string,
         public threadTs: string,
         public infos: DisplaySlackMessageInfo[],
     ) {
+        this.client = this.slack.getClientOf(this.teamID);
     }
 
     get dataStore(): DataStore {
@@ -82,7 +85,7 @@ export class PostMessageContext implements SubmitContext {
         if (nextIndex < 0) { return; }
 
         this.channelLikeID = this.infos[nextIndex].message.channelID;
-        this.client = this.infos[nextIndex].client;
+        this.client = this.slack.getClientOf(this.infos[nextIndex].message.teamID);
         this.teamID = this.infos[nextIndex].message.teamID;
         this.ts = this.infos[nextIndex].message.ts;
         this.threadTs = this.infos[nextIndex].message.threadTs;

--- a/src/services/slack/slack-client.ts
+++ b/src/services/slack/slack-client.ts
@@ -168,6 +168,7 @@ export interface SlackClient {
     dataStore: DataStore;
     subTeams: string[];
     team: Team;
+    teamID: string;
     channels: Channel[];
     attachmentTextParser: SlackParser;
 
@@ -235,6 +236,10 @@ export class SlackClientImpl implements SlackClient {
 
     get team(): Team {
         return this.rtm.dataStore.getTeamById(this.rtm.teamID);
+    }
+
+    get teamID(): string {
+        return this.rtm.teamID;
     }
 
     get channels(): Channel[] {

--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -46,7 +46,6 @@ export class DisplaySlackMessageInfo {
     constructor(
         public message: SlackMessage,
         public parser: SlackParser,
-        public client: SlackClient
     ) {
     }
 
@@ -264,7 +263,7 @@ export class SlackService {
 
     async addMessage(message: SlackMessage, parser: SlackParser, client: SlackClient): Promise<void> {
         if (message.message) {
-            const info = new DisplaySlackMessageInfo(message, parser, client);
+            const info = new DisplaySlackMessageInfo(message, parser);
             this.infos.unshift(info);
 
             if (message.message.file && message.message.file.mimetype.indexOf('image') !== -1) {
@@ -289,8 +288,9 @@ export class SlackService {
         return '';
     }
 
-    async deleteMessage(message: SlackMessage, client: SlackClient): Promise<void> {
+    async deleteMessage(message: SlackMessage): Promise<void> {
         if (message.message) {
+            const client = this.getClientOf(message.teamID);
             client.deleteMessage(message.channelID, message.ts);
         }
     }
@@ -315,5 +315,13 @@ export class SlackService {
             edited.message.rawMessage.attachments = message.rawMessage.message.attachments;
             this._onChange.next(this);
         }
+    }
+
+    getClientOf(teamID: string): SlackClient {
+        return this.clients.find(c => c.teamID === teamID);
+    }
+
+    get numTeams(): number {
+        return this.clients.length;
     }
 }


### PR DESCRIPTION
This PR removes the dependency of `DisplaySlackMessageInfo` to `SlackClient`, because the dependency is unnecessary (a `SlackClient` exists only for each team, but not for each message) and it complicates the code.